### PR TITLE
Add feature to set how the image must be subsample by the decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,29 @@
 react-native-image-to-base64
 ============================
 
-## Installation
+## Installation 🚀
 
 - Run `npm install react-native-image-to-base64 --save`
 - Run `react-native link react-native-image-to-base64` (RN 0.29.1+, otherwise `rnpm link react-native-image-to-base64`)
 
-## Usage
+## Usage 💃
+
+| Property | Type | Parameters | Description |
+|-----------------|----------|----------|--------------------------------------------|
+| `getBase64String` | `Function` | `(uri: string, callback: function, inSampleSize: int (ANDROID ONLY, NOT REQUIRED))` | Function to get the base 64 string, first parameter is the URI of the file, second is the callback and the third one is ANDROID ONLY and is to set how the image must be subsampled by the decoder |
 
 ```javascript
-NativeModules.RNImageToBase64.getBase64String(uri, (err, base64) => {
-  // Do something with the base64 string
-})
+import ImgToBase64 from 'react-native-image-to-base64';
+
+ImgToBase64.getBase64String(
+  doc,
+  (err, base64string) => {
+    if (err) {
+      throw {code: '', message: 'image_conversion_failed'}
+    }
+    console.log('ImageToBase64', base64string)
+    // Do something with base64
+  },
+  1 // Optional
+)
 ```

--- a/README.md
+++ b/README.md
@@ -10,20 +10,16 @@ react-native-image-to-base64
 
 | Property | Type | Parameters | Description |
 |-----------------|----------|----------|--------------------------------------------|
-| `getBase64String` | `Function` | `(uri: string, callback: function, inSampleSize: int (ANDROID ONLY, NOT REQUIRED))` | Function to get the base 64 string, first parameter is the URI of the file, second is the callback and the third one is ANDROID ONLY and is to set how the image must be subsampled by the decoder |
+| `getBase64String` | `Function` | `(uri: string, inSampleSize: int (ANDROID ONLY, NOT REQUIRED))` | Function to get the base 64 string, first parameter is the URI of the file, second is ANDROID ONLY and is to set how the image must be subsampled by the decoder |
 
 ```javascript
 import ImgToBase64 from 'react-native-image-to-base64';
 
-ImgToBase64.getBase64String(
-  doc,
-  (err, base64string) => {
-    if (err) {
-      throw {code: '', message: 'image_conversion_failed'}
-    }
-    console.log('ImageToBase64', base64string)
-    // Do something with base64
-  },
-  1 // Optional
-)
+try {
+  const base64string = await ImgToBase64.getBase64String(path, 1)
+  console.log(base64string)
+  // Do something with base64
+} catch(error) {
+  console.log(error)
+}
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,16 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: 'com.android.library'
 
 android {
-  compileSdkVersion 23
-  buildToolsVersion "25.0.2"
+  compileSdkVersion safeExtGet('compileSdkVersion', 23)
+  buildToolsVersion safeExtGet('buildToolsVersion', '25.0.0')
 
   defaultConfig {
-    minSdkVersion 16
-    targetSdkVersion 23
+    minSdkVersion safeExtGet('minSdkVersion', 16)
+    targetSdkVersion safeExtGet('targetSdkVersion', 22)
     versionCode 1
     versionName "1.0"
   }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet('minSdkVersion', 16)
-    targetSdkVersion safeExtGet('targetSdkVersion', 22)
+    targetSdkVersion safeExtGet('targetSdkVersion', 23)
     versionCode 1
     versionName "1.0"
   }

--- a/android/src/main/java/com/github/xfumihiro/react_native_image_to_base64/ImageToBase64Module.java
+++ b/android/src/main/java/com/github/xfumihiro/react_native_image_to_base64/ImageToBase64Module.java
@@ -5,6 +5,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.Callback;
 
 import java.util.Map;
@@ -34,7 +35,7 @@ public class ImageToBase64Module extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void getBase64String(String uri, Integer inSampleSize, Callback callback) {
+  public void getBase64String(String uri, Integer inSampleSize, final Promise promise) {
     try {
       BitmapFactory.Options options = new BitmapFactory.Options();
       options.inSampleSize = inSampleSize;
@@ -44,11 +45,12 @@ public class ImageToBase64Module extends ReactContextBaseJavaModule {
       Bitmap image = BitmapFactory.decodeFileDescriptor(fileDescriptor.getFileDescriptor(), null, options);
 
       if (image == null) {
-        callback.invoke("Failed to decode Bitmap, uri: " + uri);
+        promise.reject("EUNSPECIFIED", "Failed to decode Bitmap, uri: " + uri);
       } else {
-        callback.invoke(null, bitmapToBase64(image));
+        promise.resolve(bitmapToBase64(image));
       }
     } catch (IOException e) {
+      promise.reject("EUNSPECIFIED", "Error");
     }
   }
 

--- a/android/src/main/java/com/github/xfumihiro/react_native_image_to_base64/ImageToBase64Module.java
+++ b/android/src/main/java/com/github/xfumihiro/react_native_image_to_base64/ImageToBase64Module.java
@@ -34,7 +34,7 @@ public class ImageToBase64Module extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void getBase64String(String uri, Callback callback, Integer inSampleSize) {
+  public void getBase64String(String uri, Integer inSampleSize, Callback callback) {
     try {
       BitmapFactory.Options options = new BitmapFactory.Options();
       options.inSampleSize = inSampleSize;

--- a/android/src/main/java/com/github/xfumihiro/react_native_image_to_base64/ImageToBase64Module.java
+++ b/android/src/main/java/com/github/xfumihiro/react_native_image_to_base64/ImageToBase64Module.java
@@ -34,10 +34,10 @@ public class ImageToBase64Module extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void getBase64String(String uri, Callback callback) {
+  public void getBase64String(String uri, Callback callback, Integer inSampleSize) {
     try {
       BitmapFactory.Options options = new BitmapFactory.Options();
-      options.inSampleSize = 5;
+      options.inSampleSize = inSampleSize;
 
       AssetFileDescriptor fileDescriptor = null;
       fileDescriptor = this.context.getContentResolver().openAssetFileDescriptor(Uri.parse(uri), "r");

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const ImageToBase64 = {};
 
 ImageToBase64.getBase64String = (uri, callback, inSampleSize = 5) => {
   if (Platform.OS === "android") {
-    return RNImageToBase64.getBase64String(uri, callback, inSampleSize);
+    return RNImageToBase64.getBase64String(uri, inSampleSize, callback);
   }
   return RNImageToBase64.getBase64String(uri, callback);
 }

--- a/index.js
+++ b/index.js
@@ -1,10 +1,13 @@
-import { NativeModules } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 
 const RNImageToBase64 = NativeModules.RNImageToBase64;
 
 const ImageToBase64 = {};
 
-ImageToBase64.getBase64String = (uri, callback) => {
+ImageToBase64.getBase64String = (uri, callback, inSampleSize = 5) => {
+  if (Platform.OS === "android") {
+    return RNImageToBase64.getBase64String(uri, callback, inSampleSize);
+  }
   return RNImageToBase64.getBase64String(uri, callback);
 }
 

--- a/index.js
+++ b/index.js
@@ -4,11 +4,11 @@ const RNImageToBase64 = NativeModules.RNImageToBase64;
 
 const ImageToBase64 = {};
 
-ImageToBase64.getBase64String = (uri, callback, inSampleSize = 5) => {
+ImageToBase64.getBase64String = (uri, inSampleSize = 5) => {
   if (Platform.OS === "android") {
-    return RNImageToBase64.getBase64String(uri, inSampleSize, callback);
+    return RNImageToBase64.getBase64String(uri, inSampleSize);
   }
-  return RNImageToBase64.getBase64String(uri, callback);
+  return RNImageToBase64.getBase64String(uri);
 }
 
 ImageToBase64.bitmapToBase64 = (bitmap) => {

--- a/ios/RNImageToBase64.m
+++ b/ios/RNImageToBase64.m
@@ -1,4 +1,13 @@
+//
+//  UIImage+Orientation.m
+//  RNImageToBase64
+//
+//  Created by Selma on 19/10/2018.
+//  Copyright © 2018 xfumihiro. All rights reserved.
+//
+
 #import "RNImageToBase64.h"
+#import "UIImage+Orientation.h"
 #import <AssetsLibrary/AssetsLibrary.h>
 #import <UIKit/UIKit.h>
 
@@ -8,35 +17,23 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(getBase64String:(NSString *)input callback:(RCTResponseSenderBlock)callback)
 {
-  NSURL *url = [[NSURL alloc] initWithString:input];
-  ALAssetsLibrary *library = [[ALAssetsLibrary alloc] init];
-  [library assetForURL:url resultBlock:^(ALAsset *asset) {
-    CGImageRef imageRef = [self rotatePortraitImageFromAsset:asset];
-
-    NSData *imageData = UIImagePNGRepresentation([UIImage imageWithCGImage:imageRef]);
-    NSString *base64Encoded = [imageData base64EncodedStringWithOptions:0];
-    callback(@[[NSNull null], base64Encoded]);
-
-  } failureBlock:^(NSError *error) {
-    NSLog(@"that didn't work %@", error);
-    callback(@[error]);
-  }];
-}
-
--(CGImageRef) rotatePortraitImageFromAsset:(ALAsset*) asset {
-    ALAssetRepresentation *rep = [asset defaultRepresentation];
-
-    if ([rep orientation] == ALAssetOrientationUp){
-        return [rep fullScreenImage];
-    } else {
-        CGImageRef ref = [rep fullScreenImage];
-        UIImage* testImage = [UIImage imageWithCGImage:ref];
-
-        UIGraphicsBeginImageContextWithOptions(testImage.size, NO, testImage.scale);
-        [testImage drawInRect:(CGRect){0, 0, testImage.size}];
-        UIImage *normalizedImage = UIGraphicsGetImageFromCurrentImageContext();
-        UIGraphicsEndImageContext();
-        return [testImage CGImage];
+    @try {
+        NSURL *url = [NSURL fileURLWithPath:input];
+        NSError *err = nil;
+        NSData *imageData = [NSData dataWithContentsOfURL:url options: NSDataReadingUncached error: &err];
+        if (err != nil) {
+            callback(@[@"Not found image"]);
+            return;
+        }
+        UIImage *image = [UIImage imageWithData: imageData];
+        UIImage *portraitImage = [image normalizedImage];
+        NSData *imgData = UIImageJPEGRepresentation(portraitImage, 1.0);
+        NSString *base64 = [imgData base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+        callback(@[[NSNull null], base64]);
+    }
+    @catch (NSException *exception) {
+        NSLog(@"%@", exception.reason);
+        callback(@[exception.reason]);
     }
 }
 

--- a/ios/RNImageToBase64.m
+++ b/ios/RNImageToBase64.m
@@ -15,25 +15,24 @@
 
 RCT_EXPORT_MODULE();
 
-RCT_EXPORT_METHOD(getBase64String:(NSString *)input callback:(RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(getBase64String:(NSString *)input resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
     @try {
         NSURL *url = [NSURL fileURLWithPath:input];
         NSError *err = nil;
         NSData *imageData = [NSData dataWithContentsOfURL:url options: NSDataReadingUncached error: &err];
         if (err != nil) {
-            callback(@[@"Not found image"]);
-            return;
+            return reject(@"ENOENT", [NSString stringWithFormat:@"No such file '%@'", input], nil);
         }
         UIImage *image = [UIImage imageWithData: imageData];
         UIImage *portraitImage = [image normalizedImage];
         NSData *imgData = UIImageJPEGRepresentation(portraitImage, 1.0);
         NSString *base64 = [imgData base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
-        callback(@[[NSNull null], base64]);
+        return resolve(base64);
     }
-    @catch (NSException *exception) {
-        NSLog(@"%@", exception.reason);
-        callback(@[exception.reason]);
+    @catch (NSException *e) {
+        NSLog(@"%@", e.reason);
+        return reject(@"EUNSPECIFIED", [e reason], nil);
     }
 }
 

--- a/ios/RNImageToBase64.xcodeproj/project.pbxproj
+++ b/ios/RNImageToBase64.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B8343A4A217A05280086E4A3 /* UIImage+Orientation.m in Sources */ = {isa = PBXBuildFile; fileRef = B8343A49217A05280086E4A3 /* UIImage+Orientation.m */; };
 		E73848ED1D91319000276525 /* RNImageToBase64.m in Sources */ = {isa = PBXBuildFile; fileRef = E73848EC1D91319000276525 /* RNImageToBase64.m */; };
 /* End PBXBuildFile section */
 
@@ -23,6 +24,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		B8343A48217A05280086E4A3 /* UIImage+Orientation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImage+Orientation.h"; sourceTree = "<group>"; };
+		B8343A49217A05280086E4A3 /* UIImage+Orientation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Orientation.m"; sourceTree = "<group>"; };
 		E73848EB1D91319000276525 /* RNImageToBase64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNImageToBase64.h; sourceTree = "<group>"; };
 		E73848EC1D91319000276525 /* RNImageToBase64.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNImageToBase64.m; sourceTree = "<group>"; };
 		E7E77AF21D911ED5004B91C7 /* libRNImageToBase64.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNImageToBase64.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -42,6 +45,8 @@
 		E7E77AE91D911ED5004B91C7 = {
 			isa = PBXGroup;
 			children = (
+				B8343A48217A05280086E4A3 /* UIImage+Orientation.h */,
+				B8343A49217A05280086E4A3 /* UIImage+Orientation.m */,
 				E73848EB1D91319000276525 /* RNImageToBase64.h */,
 				E73848EC1D91319000276525 /* RNImageToBase64.m */,
 				E7E77AF31D911ED5004B91C7 /* Products */,
@@ -112,6 +117,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B8343A4A217A05280086E4A3 /* UIImage+Orientation.m in Sources */,
 				E73848ED1D91319000276525 /* RNImageToBase64.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/UIImage+Orientation.h
+++ b/ios/UIImage+Orientation.h
@@ -1,0 +1,15 @@
+//
+//  UIImage+Orientation.h
+//  RNImageToBase64
+//
+//  Created by Selma on 19/10/2018.
+//  Copyright © 2018 xfumihiro. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIImage (Orientation)
+
+- (UIImage *)normalizedImage;
+
+@end

--- a/ios/UIImage+Orientation.m
+++ b/ios/UIImage+Orientation.m
@@ -1,0 +1,23 @@
+//
+//  UIImage+Orientation.m
+//  RNImageToBase64
+//
+//  Created by Selma on 19/10/2018.
+//  Copyright © 2018 xfumihiro. All rights reserved.
+//
+
+#import "UIImage+Orientation.h"
+
+@implementation UIImage (Orientation)
+
+- (UIImage *)normalizedImage {
+    if (self.imageOrientation == UIImageOrientationUp) return self;
+    
+    UIGraphicsBeginImageContextWithOptions(self.size, NO, self.scale);
+    [self drawInRect:(CGRect){0, 0, self.size}];
+    UIImage *normalizedImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return normalizedImage;
+}
+
+@end


### PR DESCRIPTION
Before it was set to 5 by default, that means that is was considerably altering the quality of the image, I added the possibility to set it to our needs.

To see more information about this options : https://developer.android.com/reference/android/graphics/BitmapFactory.Options#inSampleSize

Edit : I also added safeExtGet so the plugin doesn't have any conflict with main project configuration.
Edit: Fix iOS, it was not working anymore. ALA lib was deprecated.